### PR TITLE
ENH: Automated Homing

### DIFF
--- a/btms_ui/ui/btms-homing.ui
+++ b/btms_ui/ui/btms-homing.ui
@@ -14,21 +14,21 @@
    <string>Stage Stack Homing</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
+   <item row="1" column="0">
     <widget class="QLabel" name="status_label">
      <property name="text">
       <string>Status</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="4" column="1">
     <widget class="QPushButton" name="cancel_button">
      <property name="text">
       <string>Cancel</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QPushButton" name="home_button">
      <property name="text">
       <string>Home Stage</string>
@@ -36,13 +36,6 @@
     </widget>
    </item>
    <item row="2" column="0" colspan="2">
-    <widget class="QProgressBar" name="progress_bar">
-     <property name="value">
-      <number>24</number>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
     <widget class="QScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
@@ -53,7 +46,7 @@
         <x>0</x>
         <y>0</y>
         <width>462</width>
-        <height>202</height>
+        <height>181</height>
        </rect>
       </property>
       <widget class="QLabel" name="status_text">
@@ -97,6 +90,27 @@
        </property>
       </widget>
      </widget>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QProgressBar" name="progress_bar">
+     <property name="value">
+      <number>24</number>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="window_label">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+       <underline>true</underline>
+      </font>
+     </property>
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/btms_ui/ui/btms-homing.ui
+++ b/btms_ui/ui/btms-homing.ui
@@ -14,10 +14,10 @@
    <string>Stage Stack Homing</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0">
-    <widget class="QPushButton" name="home_button">
+   <item row="0" column="0">
+    <widget class="QLabel" name="status_label">
      <property name="text">
-      <string>Home Stage</string>
+      <string>Status</string>
      </property>
     </widget>
    </item>
@@ -28,10 +28,10 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="status_label">
+   <item row="3" column="0">
+    <widget class="QPushButton" name="home_button">
      <property name="text">
-      <string>Status</string>
+      <string>Home Stage</string>
      </property>
     </widget>
    </item>
@@ -43,37 +43,60 @@
     </widget>
    </item>
    <item row="1" column="0" colspan="2">
-    <widget class="QLabel" name="status_text">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="autoFillBackground">
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
       <bool>true</bool>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <property name="lineWidth">
-      <number>1</number>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::PlainText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>462</width>
+        <height>202</height>
+       </rect>
+      </property>
+      <widget class="QLabel" name="status_text">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>461</width>
+         <height>201</height>
+        </rect>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="autoFillBackground">
+        <bool>true</bool>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::Panel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Plain</enum>
+       </property>
+       <property name="lineWidth">
+        <number>1</number>
+       </property>
+       <property name="text">
+        <string>TextLabel</string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::PlainText</enum>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/btms_ui/ui/btms-homing.ui
+++ b/btms_ui/ui/btms-homing.ui
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>482</width>
+    <height>301</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Stage Stack Homing</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="0">
+    <widget class="QPushButton" name="home_button">
+     <property name="text">
+      <string>Home Stage</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QPushButton" name="cancel_button">
+     <property name="text">
+      <string>Cancel</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="status_label">
+     <property name="text">
+      <string>Status</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QProgressBar" name="progress_bar">
+     <property name="value">
+      <number>24</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="status_text">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="autoFillBackground">
+      <bool>true</bool>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>1</number>
+     </property>
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/btms_ui/ui/btms-homing.ui
+++ b/btms_ui/ui/btms-homing.ui
@@ -14,91 +14,6 @@
    <string>Stage Stack Homing</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <widget class="QLabel" name="status_label">
-     <property name="text">
-      <string>Status</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QPushButton" name="cancel_button">
-     <property name="text">
-      <string>Cancel</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QPushButton" name="home_button">
-     <property name="text">
-      <string>Home Stages</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>462</width>
-        <height>181</height>
-       </rect>
-      </property>
-      <widget class="QLabel" name="status_text">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>461</width>
-         <height>201</height>
-        </rect>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="autoFillBackground">
-        <bool>true</bool>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::Panel</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Plain</enum>
-       </property>
-       <property name="lineWidth">
-        <number>1</number>
-       </property>
-       <property name="text">
-        <string>TextLabel</string>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::PlainText</enum>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </widget>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QProgressBar" name="progress_bar">
-     <property name="value">
-      <number>24</number>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="window_label">
      <property name="font">
@@ -110,6 +25,41 @@
      </property>
      <property name="text">
       <string>TextLabel</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QPushButton" name="home_button">
+     <property name="text">
+      <string>Home Stages</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QProgressBar" name="progress_bar">
+     <property name="value">
+      <number>24</number>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QTextEdit" name="status_text">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="status_label">
+     <property name="text">
+      <string>Status</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QPushButton" name="cancel_button">
+     <property name="text">
+      <string>Cancel</string>
      </property>
     </widget>
    </item>

--- a/btms_ui/ui/btms-homing.ui
+++ b/btms_ui/ui/btms-homing.ui
@@ -31,7 +31,7 @@
    <item row="4" column="0">
     <widget class="QPushButton" name="home_button">
      <property name="text">
-      <string>Home Stage</string>
+      <string>Home Stages</string>
      </property>
     </widget>
    </item>

--- a/btms_ui/ui/btms-source.ui
+++ b/btms_ui/ui/btms-source.ui
@@ -463,21 +463,119 @@
        </widget>
       </item>
       <item>
-       <widget class="PyDMDrawingCircle" name="home_status_circle">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
+       <widget class="PyDMByteIndicator" name="lin_home_indicator">
         <property name="toolTip">
          <string/>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="channel" stdset="0">
+         <string/>
+        </property>
+        <property name="showLabels" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="bigEndian" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="circles" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="numBits" stdset="0">
+         <number>1</number>
+        </property>
+        <property name="shift" stdset="0">
+         <number>14</number>
+        </property>
+        <property name="labels" stdset="0">
+         <stringlist>
+          <string>Linear</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="PyDMByteIndicator" name="rot_home_indicator">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="channel" stdset="0">
+         <string/>
+        </property>
+        <property name="showLabels" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="bigEndian" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="circles" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="numBits" stdset="0">
+         <number>1</number>
+        </property>
+        <property name="shift" stdset="0">
+         <number>14</number>
+        </property>
+        <property name="labels" stdset="0">
+         <stringlist>
+          <string>Rotary</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="PyDMByteIndicator" name="gon_home_indicator">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="channel" stdset="0">
+         <string/>
+        </property>
+        <property name="showLabels" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="bigEndian" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="circles" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="numBits" stdset="0">
+         <number>1</number>
+        </property>
+        <property name="shift" stdset="0">
+         <number>14</number>
+        </property>
+        <property name="labels" stdset="0">
+         <stringlist>
+          <string>Goniometer</string>
+         </stringlist>
         </property>
        </widget>
       </item>
@@ -938,9 +1036,9 @@
    <header>pydm.widgets.label</header>
   </customwidget>
   <customwidget>
-   <class>PyDMDrawingCircle</class>
+   <class>PyDMByteIndicator</class>
    <extends>QWidget</extends>
-   <header>pydm.widgets.drawing</header>
+   <header>pydm.widgets.byte</header>
   </customwidget>
   <customwidget>
    <class>TyphosPositionerWidget</class>

--- a/btms_ui/ui/btms-source.ui
+++ b/btms_ui/ui/btms-source.ui
@@ -456,6 +456,55 @@
        </spacer>
       </item>
       <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Home Status:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="PyDMDrawingCircle" name="home_status_circle">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="motion_home_button">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Home Stages</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_11">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
        <widget class="QPushButton" name="save_nominal_button">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -887,6 +936,11 @@
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMDrawingCircle</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
   </customwidget>
   <customwidget>
    <class>TyphosPositionerWidget</class>

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 import numpy as np
 from ophyd.epics_motor import HomeEnum
 from ophyd.status import MoveStatus
+from ophyd.utils.epics_pvs import _wait_for_value
 from pcdsdevices.lasers import btms_config
 from pcdsdevices.lasers.btms_config import DestinationPosition, SourcePosition
 from pcdsdevices.lasers.btps import (BtpsSourceStatus, BtpsState,
@@ -231,12 +232,7 @@ class HomingThread(QtCore.QThread):
 
     def calibrate(self):
         self._motor.do_calib.put(1)
-        n = 0
-        while self.needs_calib():
-            time.sleep(1)
-            n += 1
-            if n >= 10:
-                break
+        _wait_for_value(self._motor.needs_calib, timeout=10.0)
 
     def motor_error(self, motor):
         """

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -488,6 +488,7 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
     def _append_status_text(self, new_text):
         txt = self.status_text.text()
         self.status_text.setText(txt + new_text)
+        self.status_text.setText(txt + new_text)
 
     def _increment_progress(self):
         """
@@ -503,7 +504,8 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
         #       indeterminate home times?
 
         self.progress_bar.setVisible(True)
-        self._append_status_text('\nHoming...')
+        # Clear status text on each button press
+        self.status_text.setText('Homing...')
         self.n_actions = 0
 
         # Expect a tuple of (linear, rotary, goniometer) from self.positioners

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -336,7 +336,12 @@ class _rotary_thread(HomingThread):
                     direction = HomeEnum.forward
                 else:
                     direction = HomeEnum.reverse
-                self._st = rotary.home(direction, wait=False, timeout=60.0)
+                # Some of the rotary stages can only move at ~1.5 deg/sec when
+                # homing. Their range is ~270degrees, meaning that if the
+                # stage will need to move a max of ~540 degrees to guarantee
+                # the home mark is found. This comes out to a timeout value of
+                # 360 seconds. :(
+                self._st = rotary.home(direction, wait=False, timeout=360.0)
                 self._st.wait()
                 pos = rotary.user_readback.get()
                 if rotary.homed and self._rotary_pos_valid(pos):

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -708,11 +708,14 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
         txt = self.status_text.text()
         self.status_text.setText(txt + new_text)
 
-    def _update_progress(self, motor):
-        ndone = sum([int(thread.succeeded()) for thread in self._threads])
+    def _update_progress(self, thread):
+        ndone = sum([int(th.succeeded()) for th in self._threads])
         overall = np.clip(ndone / len(self._threads), 0, 1)
         self.progress_bar.setValue(int(100.0 * overall))
-        self._append_status_text(f'\nComplete: {motor}')
+        if thread.succeeded():
+            self._append_status_text(f'\nComplete: {thread._motor}')
+        else:
+            self._append_status_text(f'\nFAILED: {thread._motor}')
 
     def _perform_home(self):
         """
@@ -724,7 +727,7 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
             self._append_status_text(f'\nHoming {thread._motor} ...')
             thread.start()
             thread._finished.connect(
-                partial(self._update_progress, thread._motor)
+                partial(self._update_progress, thread)
             )
 
         show_progress = any(thread.isRunning() for thread in self._threads)

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -546,10 +546,10 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
                 return False
             if forward:
                 self._append_status_text('\nHoming linear stage forward')
-                linear.home_forward()
+                linear.home_forward.put(1)
             else:
                 self._append_status_text('\nHoming linear stage reverse')
-                linear.home_reverse()
+                linear.home_reverse.put(1)
             time.sleep(1)  # Wait a bit to allow motor to start moving
             while linear.moving:  # TODO: Add timeout here?
                 time.sleep(1)

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -232,7 +232,7 @@ class HomingThread(QtCore.QThread):
 
     def calibrate(self):
         self._motor.do_calib.put(1)
-        _wait_for_value(self._motor.needs_calib, timeout=10.0)
+        _wait_for_value(self._motor.needs_calib, 0, timeout=10.0)
 
     def motor_error(self, motor):
         """

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -520,7 +520,7 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
         #       indeterminate home times?
 
         # New home request, clear cancel
-        self.cancel = True
+        self.cancel = False
 
         self.progress_bar.setVisible(True)
         # Clear status text on each button press
@@ -556,7 +556,7 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
                 if self.cancel:
                     return False
             pos = linear.user_readback.get()
-            self._append_status_text('\nReached position {pos}')
+            self._append_status_text(f'\nReached position {pos}')
             if linear.homed:
                 loop_counter -= 1
                 lin_pos.append(pos)
@@ -566,6 +566,7 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
                 if self._motor_error(linear):
                     # if we fail in the forward direction, try backward
                     if forward:
+                        forward = False
                         txt = '\nHad error in forward direction, reversing...'
                         self._append_status_text(txt)
                         # Account for the additional moves we've made in the

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -710,7 +710,7 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
         Home the motors for this laser source.
         """
         self.progress_bar.setValue(0)
-
+        self._append_status_text('\n----------------------')
         for thread in self._threads:
             self._append_status_text(f'\nHoming {thread._motor} ...')
             thread.start()

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -620,6 +620,7 @@ class BtmsMoveConflictWidget(DesignerDisplay, QtWidgets.QFrame):
 class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
     filename: ClassVar[str] = "btms-homing.ui"
 
+    window_label: QtWidgets.QLabel
     status_label: QtWidgets.QLabel
     status_text: QtWidgets.QListWidget
     home_button: QtWidgets.QPushButton
@@ -632,7 +633,8 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
     def __init__(
         self,
         parent: QtWidgets.QWidget | None,
-        positioners: tuple[TyphosPositionerWidget, ...]
+        positioners: tuple[TyphosPositionerWidget, ...],
+        ls_name: str
     ):
         super().__init__(parent)
 
@@ -649,6 +651,7 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
             self.goniometer_thread
         ]
 
+        self.window_label.setText(ls_name)
         self.positioners = positioners
         self.status_text.setText('Ready')
         self.progress_bar.setVisible(False)
@@ -1146,7 +1149,8 @@ class BtmsSourceOverviewWidget(DesignerDisplay, QtWidgets.QFrame):
     def show_home(self):
         self._homing = BtmsHomingScreen(
             parent=None,
-            positioners=self.positioner_widgets
+            positioners=self.positioner_widgets,
+            ls_name=self.device.source_pos.name_and_desc
         )
         self._homing.show()
 

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -854,6 +854,9 @@ class BtmsSourceOverviewWidget(DesignerDisplay, QtWidgets.QFrame):
     motion_stop_button: QtWidgets.QPushButton
     motor_frame: QtWidgets.QFrame
     motion_home_button: QtWidgets.QPushButton
+    lin_home_indicator: pydm_widgets.PyDMByteIndicator
+    rot_home_indicator: pydm_widgets.PyDMByteIndicator
+    gon_home_indicator: pydm_widgets.PyDMByteIndicator
     rotary_widget: TyphosPositionerWidget
     save_nominal_button: QtWidgets.QPushButton
     save_centroid_nominal_button: QtWidgets.QPushButton
@@ -1292,6 +1295,9 @@ class BtmsSourceOverviewWidget(DesignerDisplay, QtWidgets.QFrame):
         self.linear_label.channel = channel_from_signal(device.linear.user_readback)
         self.rotary_label.channel = channel_from_signal(device.rotary.user_readback)
         self.goniometer_label.channel = channel_from_signal(device.goniometer.user_readback)
+        self.lin_home_indicator.channel = f"ca://{self.linear_widget.device.prefix}.MSTA"
+        self.rot_home_indicator.channel = f"ca://{self.rotary_widget.device.prefix}.MSTA"
+        self.gon_home_indicator.channel = f"ca://{self.goniometer_widget.device.prefix}.MSTA"
         self.near_x_label.channel = f"ca://{device.source_pos.near_field_camera_prefix}Stats2:CentroidX_RBV"
         self.near_y_label.channel = f"ca://{device.source_pos.near_field_camera_prefix}Stats2:CentroidY_RBV"
         self.far_x_label.channel = f"ca://{device.source_pos.far_field_camera_prefix}Stats2:CentroidX_RBV"

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -631,7 +631,7 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
 
     window_label: QtWidgets.QLabel
     status_label: QtWidgets.QLabel
-    status_text: QtWidgets.QListWidget
+    status_text: QtWidgets.QTextEdit
     home_button: QtWidgets.QPushButton
     cancel_button: QtWidgets.QPushButton
     progress_bar: QtWidgets.QProgressBar
@@ -696,8 +696,7 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
                 dev.stop()
 
     def _append_status_text(self, new_text):
-        txt = self.status_text.text()
-        self.status_text.setText(txt + new_text)
+        self.status_text.append(new_text)
 
     def _update_progress(self, thread):
         ndone = sum([int(th.succeeded()) for th in self._threads])

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -519,6 +519,9 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
         # TODO: Make this smarter with MoveStatus (how to do this cleanly with
         #       indeterminate home times?
 
+        # New home request, clear cancel
+        self.cancel = True
+
         self.progress_bar.setVisible(True)
         # Clear status text on each button press
         self.status_text.setText('Homing...')

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -647,7 +647,6 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
     ):
         super().__init__(parent)
 
-        self.cancel = False
         self.running = False
 
         self.linear_thread = _linear_thread(positioners[0].device)
@@ -679,7 +678,6 @@ class BtmsHomingScreen(DesignerDisplay, QtWidgets.QFrame):
         event.accept()
 
     def _cancel_button_press(self):
-        self.cancel = True
         self.cancel_requested.emit()
 
     def _cancel_handler(self):

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -1265,7 +1265,6 @@ class BtmsSourceOverviewWidget(DesignerDisplay, QtWidgets.QFrame):
         if not self._expert_mode:
             self.show_motors(False)
             self.save_centroid_nominal_button.setVisible(self._expert_mode)
-            self.motion_home_button.setVisible(self._expert_mode)
             self.toggle_control_button.setChecked(False)
 
     @QtCore.Property(str)

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -339,7 +339,7 @@ class _rotary_thread(HomingThread):
                     direction = HomeEnum.forward
                 else:
                     direction = HomeEnum.reverse
-                st = rotary.home(direction, wait=False, timeout=30.0)
+                st = rotary.home(direction, wait=False, timeout=60.0)
                 while not self.stopped():
                     time.sleep(0.1)
                     if st.done:

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -288,11 +288,12 @@ class _linear_thread(HomingThread):
             else:
                 break
 
-        if all([
-            self._linear_pos_valid(lin_pos[0], lin_pos[1]),
-            self._linear_pos_valid(lin_pos[1], lin_pos[2])
-        ]):
-            self.success()
+        if not self.stopped():
+            if all([
+                self._linear_pos_valid(lin_pos[0], lin_pos[1]),
+                self._linear_pos_valid(lin_pos[1], lin_pos[2])
+            ]):
+                self.success()
         self._finished.emit()
 
 

--- a/run.sh
+++ b/run.sh
@@ -6,4 +6,4 @@ source /reg/g/pcds/engineering_tools/latest-released/scripts/dev_conda ""
 
 cd $SCRIPT_DIR
 
-python -m btms_ui.main "$@"
+python -m btms_ui.main "$@" &

--- a/run.sh
+++ b/run.sh
@@ -6,4 +6,4 @@ source /reg/g/pcds/engineering_tools/latest-released/scripts/dev_conda ""
 
 cd $SCRIPT_DIR
 
-python -m btms_ui.bin.main "$@" &
+python -m btms_ui.main "$@"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds a button to open a screen that implements automated homing routines for the BTMS system stage stacks. Each stage type has a separate routine that is executed in a separate thread to allow for concurrent homing. 
Homing status indicators have been added to the main motion screen for each source, indicating the home state of each stage individually. 
Fixes a bug in the ```run.sh``` entry point. 


## Motivation and Context
closes #2 

Related Jira ticket: https://jira.slac.stanford.edu/browse/ECS-5498

## How Has This Been Tested?
Tested using the stages installed in the NEH beam transport system. 

## Where Has This Been Documented?
This PR and the Jira ticket. 

I've also updated the Confluence usage page accordingly here: https://confluence.slac.stanford.edu/display/L2SI/Beam+Transport+Motion+System

## Screenshots
New Expert Screen
![image](https://github.com/user-attachments/assets/c10d152f-1e71-42fe-90a1-b405c707c88b)

Homing Screen (example homing routine in-progress)
![image](https://github.com/user-attachments/assets/e800fa0a-32b0-4969-8842-558f7a67ae2e)

Failed homing routine: 
![image](https://github.com/user-attachments/assets/87e83302-24e9-4669-b68b-c6575fa67923)

