### PR TITLE
Add IOC Reboot and BTPS Buttons

### DIFF
--- a/btms_ui/ui/btms.ui
+++ b/btms_ui/ui/btms.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1282</width>
+    <width>1288</width>
     <height>500</height>
    </rect>
   </property>
@@ -108,7 +108,7 @@
             <string>IOC Reboot</string>
            </property>
            <property name="channel" stdset="0">
-            <string>IOC:LAS:BTS:MCS2:01:SYSRESET</string>
+            <string>ca://IOC:LAS:BTS:MCS2:01:SYSRESET</string>
            </property>
            <property name="showConfirmDialog" stdset="0">
             <bool>true</bool>

--- a/btms_ui/ui/btms.ui
+++ b/btms_ui/ui/btms.ui
@@ -97,6 +97,28 @@
           </widget>
          </item>
          <item>
+          <widget class="PyDMPushButton" name="ioc_reboot_button">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>IOC Reboot</string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>IOC:LAS:BTS:MCS2:01:SYSRESET</string>
+           </property>
+           <property name="showConfirmDialog" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="pressValue" stdset="0">
+            <string>1</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="button_spacer_2">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -253,8 +275,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>518</width>
-            <height>386</height>
+            <width>572</width>
+            <height>400</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -400,6 +422,11 @@
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
   </customwidget>
   <customwidget>
    <class>BtmsDiagramWidget</class>

--- a/btms_ui/widgets.py
+++ b/btms_ui/widgets.py
@@ -1431,8 +1431,7 @@ class BtmsMain(DesignerDisplay, QtWidgets.QWidget):
             )
         )
 
-        # TODO: hiding the BTPS screen for now as a workaround
-        self.open_btps_overview_button.setVisible(False)
+        self.open_btps_overview_button.setVisible(True)
         self.open_btps_overview_button.clicked.connect(self.open_btps_overview)
         self.open_hutch_overview_button.clicked.connect(self.open_hutch_overview)
         self._btps_overview = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds a button to reboot the MCS2 IOC that supports the BTMS. 
Adds a button to open the BTPS screen. 

## Motivation and Context
Closes #19 
Closes #14 

## How Has This Been Tested?
BTPS launches as expected. Tested the reboot button this morning. 

## Where Has This Been Documented?
This PR. 
