### PR TITLE
ENH: Move away from dev_conda and freeze the latest working environment

### DIFF
--- a/btps.sh
+++ b/btps.sh
@@ -2,6 +2,8 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+export PCDS_CONVA_VER=6.0.1
+
 source /reg/g/pcds/engineering_tools/latest-released/scripts/pcds_conda ""
 
 # cd $SCRIPT_DIR

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,8 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-source /reg/g/pcds/engineering_tools/latest-released/scripts/dev_conda ""
+export PCDS_CONDA_VER=6.0.1
+source /reg/g/pcds/engineering_tools/latest-released/scripts/pcds_conda ""
 
 cd $SCRIPT_DIR
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
No more `dev_conda` shenanigans! 😠 💢 

Since we got this working pcds-6.0.1, let's keep it that way for now.

## Motivation and Context
Previous iterations were running off of `dev_conda`, which inevitably broke when we moved to py3.12 releases. Let's avoid this in the future for production releases by committing to the current latest & greatest.

## How Has This Been Tested?
The btms-gui was running off my dev branch for a bit and on Friday we ran production off of the v1.2.1 release, but I noticed the `run.sh` scripts were still using dev_conda.

## Where Has This Been Documented?
This PR and https://jira.slac.stanford.edu/browse/ECS-6489

<!--
## Screenshots (if appropriate):
-->
