### PR TITLE
BUG: fix typos

### DIFF
--- a/btps.sh
+++ b/btps.sh
@@ -2,7 +2,7 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-export PCDS_CONVA_VER=6.0.1
+export PCDS_CONDA_VER=6.0.1
 
 source /reg/g/pcds/engineering_tools/latest-released/scripts/pcds_conda ""
 

--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,7 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 export PCDS_CONDA_VER=6.0.1
+
 source /reg/g/pcds/engineering_tools/latest-released/scripts/pcds_conda ""
 
 cd $SCRIPT_DIR


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Found a typo in the wrapper script for `btps.sh` when troubleshooting the BTMS gui with the laser engineering folk.

## Motivation and Context
Until we come out with `pcds-conva` I should probably get the names right

## How Has This Been Tested?
Untested, but it is just a wrapper script on the env var. Since las-console is Rocky9 now, we need to be at lest 6.0.1 so this should be fine.

## Where Has This Been Documented?
So far, just here.

<!--
## Screenshots (if appropriate):
-->
