### PR TITLE
More SDT 2026 changes for BTPS: Stacked Screens

### DIFF
--- a/btms_ui/ui/btps/btps_stacked_screen.ui
+++ b/btms_ui/ui/btps/btps_stacked_screen.ui
@@ -1,0 +1,797 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>873</width>
+    <height>744</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="btps_overview_widget">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="macros">
+      <string>{}</string>
+     </property>
+     <property name="filename">
+      <string>btps/btps-overview.ui</string>
+     </property>
+     <property name="recursiveDisplaySearch">
+      <bool>false</bool>
+     </property>
+     <property name="loadWhenShown">
+      <bool>true</bool>
+     </property>
+     <property name="disconnectWhenHidden">
+      <bool>true</bool>
+     </property>
+     <property name="followSymlinks">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="btps_override_label">
+       <property name="text">
+        <string>BTPS System Override</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMEnumComboBox" name="btps_override_setter">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip">
+        <string/>
+       </property>
+       <property name="monitorDisp">
+        <bool>false</bool>
+       </property>
+       <property name="channel">
+        <string>ca://LTLHN:BTPS:Config:SystemOverride</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="btps_override_getter">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision">
+        <number>0</number>
+       </property>
+       <property name="showUnits">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveContent">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip">
+        <string/>
+       </property>
+       <property name="channel">
+        <string>ca://LTLHN:BTPS:Config:SystemOverride</string>
+       </property>
+       <property name="enableRichText">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::MinimumExpanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="editor_button">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>90</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>90</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QPushButton:hover {
+    background-color: #e0e0e0;
+}
+QPushButton:checked {
+	background-color: rgb(255, 170, 0);
+    color: black;
+    font-weight: bold;
+}
+QPushButton:checked:hover {
+    background-color: rgb(236, 157, 0);
+}</string>
+       </property>
+       <property name="text">
+        <string>View Mode</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_5">
+     <item row="0" column="1">
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="10">
+        <widget class="QPushButton" name="LD12_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LD 12</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="9">
+        <widget class="QPushButton" name="LD11_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LD 11</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="6">
+        <widget class="QPushButton" name="LD8_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="styleSheet">
+          <string notr="true"/>
+         </property>
+         <property name="text">
+          <string>LD 8</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="7">
+        <widget class="QPushButton" name="LD9_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LD 9</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="11">
+        <widget class="QPushButton" name="LD13_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LD 13</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="8">
+        <widget class="QPushButton" name="LD10_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LD 10</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="12">
+        <widget class="QPushButton" name="LD14_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LD 14</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="0">
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="1" column="0" alignment="Qt::AlignHCenter">
+        <widget class="QPushButton" name="LS2_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LS 2</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" alignment="Qt::AlignHCenter">
+        <widget class="QPushButton" name="LS4_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LS 4</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" alignment="Qt::AlignHCenter">
+        <widget class="QPushButton" name="LS3_button">
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LS 3</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" alignment="Qt::AlignHCenter">
+        <widget class="QPushButton" name="LS1_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LS 1</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="1">
+      <widget class="QStackedWidget" name="stackedWidget">
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <widget class="QWidget" name="page">
+        <layout class="QGridLayout" name="gridLayout_6">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;Click a laser source and a laser destination to get started.&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;By default, you will be in view mode.&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;Click the &amp;quot;View Mode&amp;quot; button to toggle it to &amp;quot;Edit Mode&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <layout class="QGridLayout" name="gridLayout_4">
+       <item row="1" column="0">
+        <widget class="QPushButton" name="LS6_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LS 6</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QPushButton" name="LS7_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LS 7</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QPushButton" name="LS5_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LS 5</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QPushButton" name="LS8_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LS 8</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="2" column="1">
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="10">
+        <widget class="QPushButton" name="LD5_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LD 5</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="9">
+        <widget class="QPushButton" name="LD4_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LD 4</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="6">
+        <widget class="QPushButton" name="LD1_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LD 1</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="7">
+        <widget class="QPushButton" name="LD2_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LD 2</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="11">
+        <widget class="QPushButton" name="LD6_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LD 6</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="12">
+        <widget class="QPushButton" name="LD7_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LD 7</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="8">
+        <widget class="QPushButton" name="LD3_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>LD 3</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMEmbeddedDisplay</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.embedded_display</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>PyDMEnumComboBox</class>
+   <extends>QComboBox</extends>
+   <header>pydm.widgets.enum_combo_box</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/btms_ui/ui/btps_prototype.py
+++ b/btms_ui/ui/btps_prototype.py
@@ -1,0 +1,283 @@
+import json
+import logging
+from functools import partial
+from typing import ClassVar
+
+from pydm.widgets import PyDMEmbeddedDisplay, PyDMEnumComboBox, PyDMLineEdit
+from qtpy.QtCore import QRegularExpression
+from qtpy.QtWidgets import QPushButton, QStackedWidget, QWidget
+
+from btms_ui import util
+from btms_ui.config import btms_config
+from btms_ui.core import DesignerDisplay
+
+logger = logging.getLogger(__name__)
+
+
+class BtpsPrototype(DesignerDisplay, QWidget):
+    filename: ClassVar[str] = "btps/btps_stacked_screen.ui"
+    stackedWidget: QStackedWidget
+    btps_overview_widget: PyDMEmbeddedDisplay
+    editor_button: QPushButton
+
+    LS1_button: QPushButton
+    LS2_button: QPushButton
+    LS3_button: QPushButton
+    LS4_button: QPushButton
+    LS5_button: QPushButton
+    LS6_button: QPushButton
+    LS7_button: QPushButton
+    LS8_button: QPushButton
+
+    LD1_button: QPushButton
+    LD2_button: QPushButton
+    LD3_button: QPushButton
+    LD4_button: QPushButton
+    LD5_button: QPushButton
+    LD6_button: QPushButton
+    LD7_button: QPushButton
+    LD8_button: QPushButton
+    LD9_button: QPushButton
+    LD10_button: QPushButton
+    LD11_button: QPushButton
+    LD12_button: QPushButton
+    LD13_button: QPushButton
+    LD14_button: QPushButton
+
+    def __init__(self, parent: QWidget | None = None,):
+        super().__init__(parent)
+        self.stackWidget_dict = {}
+        self.current_view = {"source": "LS0", "dest": "LD0"}
+        self.sources = [str(source) for source in btms_config.valid_sources]
+        self.destinations = [str(dest) for dest in btms_config.valid_destinations]
+        # Hold onto a list of embedded displays to destroy properly later
+        self._embedded_displays = []
+
+        self.btps_overview_widget.setFilename(
+            str(util.BTMS_SOURCE_PATH / "ui/btps/btps-overview.ui")
+        )
+
+        self.editor_button.toggled.connect(self.toggle_edit_button)
+        self.build_stacked_widget()
+        self.update_view()
+        self.init_buttons()
+
+    def build_stacked_widget(self) -> None:
+        """
+        Build stacked widgets for example layout
+        """
+        logger.debug("Building stacked widget")
+        # Gotta initialize and hardcode the landing page
+        self.stackWidget_dict["LS0_LD0"] = 0
+
+        for source in self.sources:
+            for dest in self.destinations:
+                self.add_stacked_frame(source, dest)
+
+    def add_stacked_frame(self, source: str, dest: str) -> None:
+        """
+        Build a frame to add to the stackedWidget
+
+        Parameters
+        ----------
+        source : int
+            Laser source identifier.  1 < source < 8.
+        dest : int
+            Laser destination identifier. 1 < dest < 14
+        """
+        temp_widget = PyDMEmbeddedDisplay(parent=self.stackedWidget)
+        macros = {"SOURCE": f"LTLHN:{dest}:{source}:",
+                  "DEST": f"LTLHN:{dest}:",
+                  "SHUTTER": f"LTLHN:{source}:BTPS:",
+                  "RANGE_SCREEN": str(util.BTMS_SOURCE_PATH / "ui/btps/btps-range-config.ui")}
+        temp_widget.setMacros(json.dumps(macros))
+        temp_widget.loadWhenShown = True
+        temp_widget.setFilename(
+            str(util.BTMS_SOURCE_PATH / "ui/btps/btps-source-dest.ui"))
+
+        temp_widget.setObjectName(f"{source}_{dest}_widget")
+        # Add it to the stacked widget
+        idx = self.stackedWidget.addWidget(temp_widget)
+        logger.debug(f"Adding {source}_{dest} widget to stacked index {idx}")
+        # Add it to the stacked widget dict
+        self.stackWidget_dict[f"{source}_{dest}"] = idx
+        self._embedded_displays.append(temp_widget)
+
+    def init_buttons(self) -> None:
+        """
+        Set up all the navigator buttons
+        """
+        logger.debug("Initializing navigator buttons")
+
+        invalid_sources = [src for src in [f"LS{i}" for i in range(1, 9)]
+                           if src not in self.sources]
+        invalid_dest = [dest for dest in [f"LD{j}" for j in range(1, 15)]
+                        if dest not in self.destinations]
+
+        for source in self.sources:
+            self.configure_button(name=f"{source}_button")
+
+        for dest in self.destinations:
+            self.configure_button(name=f"{dest}_button")
+
+        for bad_btn in invalid_sources + invalid_dest:
+            logger.debug(f"{bad_btn} is unused, hiding it.")
+            self.hide_button(bad_btn)
+
+    def configure_button(self, name: str) -> None:
+        """
+        Configure the stylesheet and make the button checkable
+        """
+        button: QPushButton
+        logger.debug(f"Configuring button: {name}")
+
+        stylesheet = """
+        QPushButton {
+            background-color: #f0f0f0;
+            border: 1px solid #ababab;
+            padding: 5px;
+            border-radius: 3px;
+        }
+        QPushButton:hover {
+            background-color: #e0e0e0;
+        }
+        QPushButton:checked {
+            background-color: #3cda02;
+            color: white;
+            font-weight: bold;
+            border: 1px solid #3dcb0a;
+        }
+        QPushButton:checked:hover {
+            background-color: #3dcb0a;
+        }
+        """
+        button = getattr(self, name)
+        button.setStyleSheet("")
+        button.setCheckable(True)
+        button.toggled.connect(partial(self.toggle_button, button))
+        button.setStyleSheet(stylesheet)
+
+    def hide_button(self, name: str) -> None:
+        """
+        Disable and hide a QPushButton for a source/dest that doesn't exist yet
+
+        Parameters
+        ----------
+        name : str
+            Name of the QPushbutton obj
+        """
+        button: QPushButton
+
+        button = getattr(self, f"{name}_button")
+        button.setEnabled(False)
+        # Paradoxically, you set the size policy for hidden objects this way
+        size_policy = button.sizePolicy()
+        size_policy.setRetainSizeWhenHidden(True)
+        button.setSizePolicy(size_policy)
+        # Then hide it without rearranging your layouts
+        button.hide()
+
+    def toggle_button(self, button: QPushButton) -> None:
+        temp: QPushButton
+
+        name = button.objectName()
+        # Check to see if this button is already active
+
+        if button.isChecked():
+            if "LS" in name:
+                iterator = self.sources
+                self.current_view["source"] = name.split('_', maxsplit=1)[0]
+            elif "LD" in name:
+                iterator = self.destinations
+                self.current_view["dest"] = name.split('_', maxsplit=1)[0]
+            else:
+                logger.warning(f"{name} is in an unknown state, aborting toggle!")
+                return
+
+            for it in iterator:
+                temp = getattr(self, f"{it}_button")
+                if temp != button:
+                    if temp.isChecked():
+                        self.uncheck_quietly(temp)
+
+            button.setChecked(True)
+
+        else:
+            # Then just deactivate it
+            self.uncheck_quietly(button)
+            self.current_view = {"source": "LS0", "dest": "LD0"}
+            self.update_view()
+            return
+
+        # Then we should update our view
+        self.update_view()
+
+    def uncheck_quietly(self, button: QPushButton) -> None:
+        """
+        Toggle a checkable QPushbutton without emitting a signal, avoiding accidental callbacks.
+        """
+        logger.debug(f"Quietly unchecking {button.objectName}")
+
+        button.blockSignals(True)
+        button.setChecked(False)
+        button.blockSignals(False)
+
+    def update_view(self) -> None:
+        """
+        Update the stacked widget based on the selector buttons. Use the dict to select
+        the correct index from the stackedWidget.
+        """
+
+        source = self.current_view["source"]
+        dest = self.current_view["dest"]
+
+        key = f"{source}_{dest}"
+        logger.debug(f"Received update to view {key}")
+
+        idx = self.stackWidget_dict[key] if key in self.stackWidget_dict else 0
+        logger.debug(f"Stacked view set to index: {idx}")
+
+        self.stackedWidget.setCurrentIndex(idx)
+        self.toggle_edit_widgets(enabled=self.editor_button.isChecked(),
+                                 page=self.stackedWidget.currentWidget())
+
+    def toggle_edit_button(self) -> None:
+        """
+        Handles the latched state on the editor button and updates the enable state on
+        the appropriate config edit widgets.
+        """
+        checked = self.editor_button.isChecked()
+
+        if checked:
+            logger.debug("Edit mode requested")
+            self.editor_button.setText("Edit Mode")
+        else:
+            logger.debug("View mode requested")
+            self.editor_button.setText("View Mode")
+
+        self.toggle_edit_widgets(checked)
+
+    def toggle_edit_widgets(self, enabled: bool, page: PyDMEmbeddedDisplay = None):
+        """
+        Toggle the enable and show/hide state of config edit widgets
+        """
+        widget: PyDMLineEdit | PyDMEnumComboBox
+
+        current_page = page
+
+        if not page:
+            current_page = self.stackedWidget.currentWidget()
+            logger.debug("No page detected. "
+                         f"Setting to current widget: {current_page.objectName}")
+
+        edit_widgets = current_page.findChildren((PyDMLineEdit, PyDMEnumComboBox),
+                                                 QRegularExpression("Setpoint"))
+
+        logger.debug(f"Enable state is set to {enabled} "
+                     "Updating widgets.")
+        for widget in edit_widgets:
+            widget.setEnabled(enabled)
+            if enabled:
+                widget.show()
+            else:
+                widget.hide()

--- a/btms_ui/ui/launch_btps.py
+++ b/btms_ui/ui/launch_btps.py
@@ -1,0 +1,19 @@
+from qtpy import QtWidgets
+
+from btms_ui.ui.btps_prototype import BtpsPrototype
+
+
+def main():
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+
+    widget = BtpsPrototype()
+
+    widget.show()
+
+    app.exec_()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
More scary, mountains of UI file code to add before I clean house.

Looking to spark some discussion about this approach before I overcommit the repo. Would be very interested in what @slactjohnson has to say.

I have had the Laser Systems folks look at a demo, but they said they're like to get their hands on it to iterate on features/requests. I tried to keep the bare-bones for daily operation and reduce recursive/nesting screens

Added:
1. `btps_stacked_screen.ui` which attempts to simplify the `btps-config` screen
2. Added a launcher entry point for the new `btps_screen` (but critically did not add to `pyproject.toml` yet)

Changed:
1. I am essentially _only_ using the `btps-range-config` ui inside the `btps-source-dest` embedded widgets and just hiding controls when they aren't in use. 
2. I have neglected all other screens, including the slightly confusing camera overview— which AFAIK is unused out in the wild right now.

## Motivation and Context
Tyler made a heroic effort getting a `btps` screen out in a tight turnaround some number of years ago using solely `ui` to expedite the review process, but there have been a few rough edges that we've gotten caught on a few times.

The nested tabs of tabs for `source` and `dest` were pretty error prone, since each embedded `PyDMTabWidget` wasn't aware of the source/dest state of the neighbors, which meant it was _extremely_ easy to accidentally overwrite the entire laser delivery config for the completely wrong entry. 

I, and a few of the Laser Systems guys, have done this several times over the years and it is very painful each time it happens.

Instead, I wanted an approach that would be easier for them to view and edit and while comparing to their current source of truth which exists as a table on Confluence. 

You can now _only_ be in _one_ single configuration of `LS` and `LD` at any given time, which should clear up confusion and make things a little less error prone. 

## How Has This Been Tested?
I haven't dared to edit any configs while the folks were aligning the `btms` in the prior weeks, but they have yet to push their found positions to the `btps`. I have tested opening the screen in `psbuild-rocky9` to ensure I couldn't accidentally write PVs. 

This _should_ make it easier to do for them now.

## Where Has This Been Documented?
So far just this PR, no ticket tracking this yet.

## Screenshots (if appropriate):
Here's a short demo video:

https://github.com/user-attachments/assets/a7598592-fb62-4452-b6e9-dc1b7bbad56b


